### PR TITLE
config: Update baseURL to https

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-baseURL: http://www.ellemouton.com
+baseURL: https://www.ellemouton.com
 languageCode: en-us
 title: Elle Mouton 
 theme: "PaperMod"


### PR DESCRIPTION
The favicon doesn't render on chrome because the page itself redirects
to https but the favicon does not, resulting in a "mixed content" policy
violation. Resetting the baseURL to strictly point to an https URL might
fix the issue.