### PR TITLE
cv: fix LinkedIn URL

### DIFF
--- a/cv/cv.pdf
+++ b/cv/cv.pdf
@@ -2780,11 +2780,11 @@ endobj
   /A <<
     /Type /Action
     /S /URI
-    /URI (https://www.linkedin.com/in/elle-mouton)
+    /URI (https://www.linkedin.com/in/elle-mouton-50635a143/)
   >>
   /F 4
   /StructParent 4
-  /Contents (https://www.linkedin.com/in/elle-mouton)
+  /Contents (https://www.linkedin.com/in/elle-mouton-50635a143/)
 >>
 endobj
 
@@ -13251,8 +13251,8 @@ endobj
   /Title <FEFF0045006C006C00650020004D006F00750074006F006E00202014002000430056>
   /Author (Elle Mouton)
   /Creator (Typst 0.14.2)
-  /ModDate (D:20260529105156-07'00)
-  /CreationDate (D:20260529105156-07'00)
+  /ModDate (D:20260529112534-07'00)
+  /CreationDate (D:20260529112534-07'00)
 >>
 endobj
 
@@ -13263,7 +13263,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Elle Mouton — CV</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Elle Mouton</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-05-29T10:51:56-07:00</xmp:ModifyDate><xmp:CreateDate>2026-05-29T10:51:56-07:00</xmp:CreateDate><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>+dkUv8h4vmkssY+Fgrqv6A==</xmpMM:InstanceID><xmpMM:DocumentID>4cPcWXr40iIRep2NcW4taw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Elle Mouton — CV</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Elle Mouton</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-05-29T11:25:34-07:00</xmp:ModifyDate><xmp:CreateDate>2026-05-29T11:25:34-07:00</xmp:CreateDate><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>R1KLbMtgJUw/fvYcokjk2w==</xmpMM:InstanceID><xmpMM:DocumentID>4cPcWXr40iIRep2NcW4taw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -13469,53 +13469,53 @@ xref
 0000068970 00000 n
 0000069226 00000 n
 0000069498 00000 n
-0000069790 00000 n
-0000070067 00000 n
-0000070414 00000 n
-0000070782 00000 n
-0000071101 00000 n
-0000071420 00000 n
-0000071740 00000 n
-0000072058 00000 n
-0000072376 00000 n
-0000072694 00000 n
-0000072996 00000 n
-0000073302 00000 n
-0000073608 00000 n
-0000073897 00000 n
-0000074186 00000 n
-0000074458 00000 n
-0000074762 00000 n
-0000075113 00000 n
-0000075420 00000 n
-0000075727 00000 n
-0000076007 00000 n
-0000076798 00000 n
-0000082830 00000 n
-0000168426 00000 n
-0000170174 00000 n
-0000176672 00000 n
-0000179530 00000 n
-0000190643 00000 n
-0000191465 00000 n
-0001218026 00000 n
-0001218936 00000 n
-0002448330 00000 n
-0002449542 00000 n
-0002712268 00000 n
-0002714803 00000 n
-0002718157 00000 n
-0002718762 00000 n
-0002739934 00000 n
-0002740165 00000 n
-0002741420 00000 n
+0000069812 00000 n
+0000070089 00000 n
+0000070436 00000 n
+0000070804 00000 n
+0000071123 00000 n
+0000071442 00000 n
+0000071762 00000 n
+0000072080 00000 n
+0000072398 00000 n
+0000072716 00000 n
+0000073018 00000 n
+0000073324 00000 n
+0000073630 00000 n
+0000073919 00000 n
+0000074208 00000 n
+0000074480 00000 n
+0000074784 00000 n
+0000075135 00000 n
+0000075442 00000 n
+0000075749 00000 n
+0000076029 00000 n
+0000076820 00000 n
+0000082852 00000 n
+0000168448 00000 n
+0000170196 00000 n
+0000176694 00000 n
+0000179552 00000 n
+0000190665 00000 n
+0000191487 00000 n
+0001218048 00000 n
+0001218958 00000 n
+0002448352 00000 n
+0002449564 00000 n
+0002712290 00000 n
+0002714825 00000 n
+0002718179 00000 n
+0002718784 00000 n
+0002739956 00000 n
+0002740187 00000 n
+0002741442 00000 n
 trailer
 <<
   /Size 223
   /Root 222 0 R
   /Info 220 0 R
-  /ID [(4cPcWXr40iIRep2NcW4taw==) (+dkUv8h4vmkssY+Fgrqv6A==)]
+  /ID [(4cPcWXr40iIRep2NcW4taw==) (R1KLbMtgJUw/fvYcokjk2w==)]
 >>
 startxref
-2741639
+2741661
 %%EOF

--- a/cv/cv.typ
+++ b/cv/cv.typ
@@ -182,7 +182,7 @@
       #h(10pt)
       #link("https://github.com/ellemouton")[#fa-github]
       #h(10pt)
-      #link("https://www.linkedin.com/in/elle-mouton")[#fa-linkedin]
+      #link("https://www.linkedin.com/in/elle-mouton-50635a143/")[#fa-linkedin]
       #h(10pt)
       #link("https://instagram.com/ellemouton")[#fa-instagram]
     ]

--- a/static/CV_Elle_Mouton.pdf
+++ b/static/CV_Elle_Mouton.pdf
@@ -2780,11 +2780,11 @@ endobj
   /A <<
     /Type /Action
     /S /URI
-    /URI (https://www.linkedin.com/in/elle-mouton)
+    /URI (https://www.linkedin.com/in/elle-mouton-50635a143/)
   >>
   /F 4
   /StructParent 4
-  /Contents (https://www.linkedin.com/in/elle-mouton)
+  /Contents (https://www.linkedin.com/in/elle-mouton-50635a143/)
 >>
 endobj
 
@@ -13251,8 +13251,8 @@ endobj
   /Title <FEFF0045006C006C00650020004D006F00750074006F006E00202014002000430056>
   /Author (Elle Mouton)
   /Creator (Typst 0.14.2)
-  /ModDate (D:20260529105156-07'00)
-  /CreationDate (D:20260529105156-07'00)
+  /ModDate (D:20260529111955-07'00)
+  /CreationDate (D:20260529111955-07'00)
 >>
 endobj
 
@@ -13263,7 +13263,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Elle Mouton — CV</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Elle Mouton</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-05-29T10:51:56-07:00</xmp:ModifyDate><xmp:CreateDate>2026-05-29T10:51:56-07:00</xmp:CreateDate><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>+dkUv8h4vmkssY+Fgrqv6A==</xmpMM:InstanceID><xmpMM:DocumentID>4cPcWXr40iIRep2NcW4taw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Elle Mouton — CV</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Elle Mouton</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-05-29T11:19:55-07:00</xmp:ModifyDate><xmp:CreateDate>2026-05-29T11:19:55-07:00</xmp:CreateDate><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>YUAt+XiEm0D7iNwwezuHdA==</xmpMM:InstanceID><xmpMM:DocumentID>4cPcWXr40iIRep2NcW4taw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -13469,53 +13469,53 @@ xref
 0000068970 00000 n
 0000069226 00000 n
 0000069498 00000 n
-0000069790 00000 n
-0000070067 00000 n
-0000070414 00000 n
-0000070782 00000 n
-0000071101 00000 n
-0000071420 00000 n
-0000071740 00000 n
-0000072058 00000 n
-0000072376 00000 n
-0000072694 00000 n
-0000072996 00000 n
-0000073302 00000 n
-0000073608 00000 n
-0000073897 00000 n
-0000074186 00000 n
-0000074458 00000 n
-0000074762 00000 n
-0000075113 00000 n
-0000075420 00000 n
-0000075727 00000 n
-0000076007 00000 n
-0000076798 00000 n
-0000082830 00000 n
-0000168426 00000 n
-0000170174 00000 n
-0000176672 00000 n
-0000179530 00000 n
-0000190643 00000 n
-0000191465 00000 n
-0001218026 00000 n
-0001218936 00000 n
-0002448330 00000 n
-0002449542 00000 n
-0002712268 00000 n
-0002714803 00000 n
-0002718157 00000 n
-0002718762 00000 n
-0002739934 00000 n
-0002740165 00000 n
-0002741420 00000 n
+0000069812 00000 n
+0000070089 00000 n
+0000070436 00000 n
+0000070804 00000 n
+0000071123 00000 n
+0000071442 00000 n
+0000071762 00000 n
+0000072080 00000 n
+0000072398 00000 n
+0000072716 00000 n
+0000073018 00000 n
+0000073324 00000 n
+0000073630 00000 n
+0000073919 00000 n
+0000074208 00000 n
+0000074480 00000 n
+0000074784 00000 n
+0000075135 00000 n
+0000075442 00000 n
+0000075749 00000 n
+0000076029 00000 n
+0000076820 00000 n
+0000082852 00000 n
+0000168448 00000 n
+0000170196 00000 n
+0000176694 00000 n
+0000179552 00000 n
+0000190665 00000 n
+0000191487 00000 n
+0001218048 00000 n
+0001218958 00000 n
+0002448352 00000 n
+0002449564 00000 n
+0002712290 00000 n
+0002714825 00000 n
+0002718179 00000 n
+0002718784 00000 n
+0002739956 00000 n
+0002740187 00000 n
+0002741442 00000 n
 trailer
 <<
   /Size 223
   /Root 222 0 R
   /Info 220 0 R
-  /ID [(4cPcWXr40iIRep2NcW4taw==) (+dkUv8h4vmkssY+Fgrqv6A==)]
+  /ID [(4cPcWXr40iIRep2NcW4taw==) (YUAt+XiEm0D7iNwwezuHdA==)]
 >>
 startxref
-2741639
+2741661
 %%EOF


### PR DESCRIPTION
## Summary
- Fix LinkedIn URL in `cv/cv.typ` to `https://www.linkedin.com/in/elle-mouton-50635a143/`
- Regenerate `cv/cv.pdf` and `static/CV_Elle_Mouton.pdf`

## Test plan
- [x] Click LinkedIn icon in the rendered CV PDF → resolves to the correct profile