### PR TITLE
web: add subtle footer link to the photography site

### DIFF
--- a/web/components/Footer.tsx
+++ b/web/components/Footer.tsx
@@ -16,6 +16,14 @@ export function Footer() {
         </a>
       </span>
       <span aria-hidden>·</span>
+      {/* Subtle cross-link to Elle's photography portfolio (separate site). */}
+      <a
+        href="https://photo.ellemouton.com"
+        className="hover:text-[color:var(--primary)]"
+      >
+        Photography
+      </a>
+      <span aria-hidden>·</span>
       <a
         href="https://github.com/ellemouton/website"
         target="_blank"


### PR DESCRIPTION
Adds a 'Photography' link (photo.ellemouton.com) to the footer, between the author name and the source-code link, so visitors can find Elle's photography portfolio from the main site.